### PR TITLE
Add support for ZendServer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,3 +21,16 @@ Available states
 
 Configure newrelic-sysmond and newrelic-php5 packages to work with your php
 application.
+
+``newrelic.zendserver``
+---------
+
+This optional state **supplements** the ``newrelic`` state which makes it
+possible to use NewRelic together with Zend Server and (optionally) the `ZendServer Formula
+<https://github.com/saltstack-formulas/zendserver-formula>`_.
+
+To use this, both the `newrelic` and the `newrelic.zendserver` states must be
+included.
+
+If you have a different "PHP API" version you can add this to the NewRelic
+pillar (key: php_api_version). This defaults to `20121212`.

--- a/newrelic/zendserver.sls
+++ b/newrelic/zendserver.sls
@@ -1,0 +1,29 @@
+# This extends the NewRelic formula with support for Zend Server's alternative setup
+include:
+  - newrelic.daemon
+  - newrelic.php
+
+# Copy the library library file
+/usr/local/zend/lib/php_extensions/newrelic.so:
+  file.copy:
+    - source: /usr/lib/newrelic-php5/agent/x64/newrelic-{{ salt['pillar.get']('newrelic:php_api_version', '20121212')}}.so
+    - mode: 755
+    - require:
+      - pkg: newrelic-php5
+    - watch_in:
+      - service: php5-fpm
+
+# Copy template to new location since it hasn't been installed by the installer
+/usr/local/zend/etc/conf.d/newrelic.ini:
+  file.copy:
+    - source: /usr/lib/newrelic-php5/scripts/newrelic.ini.template
+    - require:
+      - pkg: newrelic-php5
+
+# Make sure the name/key is set written to the correct file
+extend:
+  newrelic-php:
+    file.replace:
+      - name: /usr/local/zend/etc/conf.d/newrelic.ini
+      - watch_in:
+        - service: php5-fpm


### PR DESCRIPTION
This optional supplemental state will take care of the required changes to get this to work on ZendServer.
ZS uses different paths and because of that the installer skips certain aspects we have to do by hand now.

Tested on ZS 7.0 + PHP 5.5 @ Ubuntu 14.04.