### PR TITLE
Handle appname changes for ZS as well

### DIFF
--- a/newrelic/zendserver.sls
+++ b/newrelic/zendserver.sls
@@ -27,3 +27,8 @@ extend:
       - name: /usr/local/zend/etc/conf.d/newrelic.ini
       - watch_in:
         - service: php5-fpm
+  newrelic-appname:
+    file.replace:
+      - name: /usr/local/zend/etc/conf.d/newrelic.ini
+      - watch_in:
+        - service: php5-fpm


### PR DESCRIPTION
I based my initial work on an older revision where the appname wasn't available. 
This should catch up to that and implement that as well for the ZS variant