### PR TITLE
resolve warnings due to makedirs statement in file.replace

### DIFF
--- a/newrelic/php.sls
+++ b/newrelic/php.sls
@@ -2,14 +2,6 @@ newrelic-php:
   pkg.installed:
     - name: newrelic-php5
 
-  file.directory:
-  {% if grains['os_family'] == 'RedHat' %}
-    - name: /etc/php.d
-  {% elif grains['os_family'] == 'Debian' %}
-    - name: /etc/php5/mods-available
-  {% endif %}
-    - makedirs: True
-
   file.replace:
   {% if grains['os_family'] == 'RedHat' %}
     - name: /etc/php.d/newrelic.ini
@@ -22,6 +14,15 @@ newrelic-php:
         - service: newrelic-daemon
     - require:
         - pkg: newrelic-php5
+
+newrelic-files-folder:
+  file.directory:
+  {% if grains['os_family'] == 'RedHat' %}
+    - name: /etc/php.d
+  {% elif grains['os_family'] == 'Debian' %}
+    - name: /etc/php5/mods-available
+  {% endif %}
+    - makedirs: True
 
 newrelic-appname:
   file.replace:

--- a/newrelic/php.sls
+++ b/newrelic/php.sls
@@ -2,6 +2,14 @@ newrelic-php:
   pkg.installed:
     - name: newrelic-php5
 
+  file.directory:
+  {% if grains['os_family'] == 'RedHat' %}
+    - name: /etc/php.d
+  {% elif grains['os_family'] == 'Debian' %}
+    - name: /etc/php5/mods-available
+  {% endif %}
+    - makedirs: True
+
   file.replace:
   {% if grains['os_family'] == 'RedHat' %}
     - name: /etc/php.d/newrelic.ini
@@ -10,7 +18,6 @@ newrelic-php:
   {% endif %}
     - pattern: 'newrelic.license = .*'
     - repl: newrelic.license = "{{ salt['pillar.get']('newrelic:apikey', '') }}"
-    - makedirs: True
     - watch_in:
         - service: newrelic-daemon
     - require:
@@ -25,7 +32,6 @@ newrelic-appname:
   {% endif %}
     - pattern: 'newrelic.appname = "PHP Application"'
     - repl: newrelic.appname = "{{ salt['pillar.get']('newrelic:appname', '') }}"
-    - makedirs: True
     - watch_in:
         - service: newrelic-daemon
     - require:


### PR DESCRIPTION
The makedirs keyword is an invalid argument for file.replace.

----------
          ID: newrelic-php
    Function: file.replace
        Name: /etc/php5/mods-available/newrelic.ini
      Result: True
     Comment: No changes needed to be made
     Started: 11:02:46.381033
    Duration: 4.883 ms
     Changes:
    Warnings: 'makedirs' is an invalid keyword argument for 'file.replace'. If
              you were trying to pass additional data to be used in a template
              context, please populate 'context' with 'key: value' pairs. Your
              approach will work until Salt Carbon is out. Please update your
              state files.