### PR TITLE
Ensure newline at end of licence section

### DIFF
--- a/newrelic/nrsysmond.sls
+++ b/newrelic/nrsysmond.sls
@@ -2,7 +2,6 @@ newrelic-sysmond:
   pkg:
     - installed
   service.running:
-    - reload: True
     - watch:
         - pkg: newrelic-sysmond
         - file: /etc/newrelic/nrsysmond.cfg
@@ -20,6 +19,7 @@ add_licence_key:
     - append_if_not_found: True
     - marker_start: '#-- salt managed license key zone --'
     - marker_end: '#-- end salt managed license key --'
-    - content: license_key={{ salt['pillar.get']('newrelic:apikey', '') }}
+    - content: |
+        license_key={{ salt['pillar.get']('newrelic:apikey', '') }}
     - require:
         - pkg: newrelic-sysmond


### PR DESCRIPTION
Been meaning to PR this for a while. With the state as it was, the first execution would result in:

```
#-- salt managed license key zone --
licence_key=blah#-- end salt managed license key --
```

which, due to the semantics of `file.blockreplace` would get replaced on the second execution with

```
#-- salt managed license key zone --
licence_key=blah
licence_key=blah#-- end salt managed license key --
```

breaking the sysmond service config. 
